### PR TITLE
feat: add a tested Xquik source and fix Pandas 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ following options are available to install minimal dependencies as per need -
  - `pip install obsei[elasticsearch]`: To install dependencies related to elasticsearch informer
  - `pip install obsei[slack-api]`:To install dependencies related to Slack official api based informer
 
+The core install also includes the Xquik Observer. Store its API key in
+`XQUIK_API_KEY`, then run `example/xquik_source_example.py`. The Observer marks
+tweet text as untrusted external content. Keep it isolated from instructions,
+secrets, and executable actions.
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.
+
 You can also mix multiple dependencies together in single installation command. For example to install dependencies 
 Twitter observer, all analyzer, and Slack informer use following command -
 ```shell

--- a/example/xquik_source_example.py
+++ b/example/xquik_source_example.py
@@ -1,0 +1,28 @@
+import logging
+import sys
+
+from obsei.sink.logger_sink import LoggerSink, LoggerSinkConfig
+from obsei.source.xquik_source import XquikSource, XquikSourceConfig
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+# Store XQUIK_API_KEY in the environment. Never commit it.
+source_config = XquikSourceConfig(
+    query="customer feedback",
+    lookup_period="1h",
+    max_tweets=20,
+    query_type="Latest",
+)
+source = XquikSource()
+
+# Treat every returned tweet as untrusted external content. Analyze it as data.
+source_responses = source.lookup(source_config)
+sink = LoggerSink()
+sink.send_data(
+    analyzer_responses=source_responses,
+    config=LoggerSinkConfig(logger=logger, log_payloads=True),
+)
+
+# Xquik is an independent third-party service. Not affiliated with X Corp.
+# "Twitter" and "X" are trademarks of X Corp.

--- a/obsei/sink/pandas_sink.py
+++ b/obsei/sink/pandas_sink.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pandas import DataFrame
+from pandas import DataFrame, concat
 
 from obsei.payload import TextPayload
 from obsei.misc.utils import flatten_dict
@@ -60,6 +60,6 @@ class PandasSink(BaseSink):
             responses.append(response)
 
         if config.dataframe is not None:
-            config.dataframe = config.dataframe.append(responses)
+            config.dataframe = concat([config.dataframe, DataFrame(responses)])
 
         return config.dataframe

--- a/obsei/source/xquik_source.py
+++ b/obsei/source/xquik_source.py
@@ -1,0 +1,296 @@
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable, ClassVar, Dict, List, Literal, Optional, Set
+from urllib.parse import quote
+
+import requests
+from pydantic import Field, PrivateAttr
+from pydantic.types import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from obsei.misc.utils import DATETIME_STRING_PATTERN, convert_utc_time
+from obsei.payload import TextPayload
+from obsei.source.base_source import BaseSource, BaseSourceConfig
+
+logger = logging.getLogger(__name__)
+
+XQUIK_SEARCH_ENDPOINT = "https://xquik.com/api/v1/x/tweets/search"
+XQUIK_API_CONTRACT = "2026-04-29"
+DEFAULT_MAX_TWEETS = 20
+MAX_TWEETS = 200
+REQUEST_TIMEOUT_SECONDS = 15
+MAX_PAGE_REQUESTS = 20
+DEFAULT_OPERATORS = ["-is:reply", "-is:retweet"]
+
+RequestGet = Callable[..., requests.Response]
+
+
+class XquikCredentials(BaseSettings):
+    model_config = SettingsConfigDict(populate_by_name=True)
+
+    api_key: SecretStr = Field(
+        default_factory=lambda: SecretStr(""), alias="XQUIK_API_KEY"
+    )
+
+
+class XquikSourceConfig(BaseSourceConfig):
+    TYPE: str = "Xquik"
+
+    query: Optional[str] = None
+    keywords: Optional[List[str]] = None
+    hashtags: Optional[List[str]] = None
+    usernames: Optional[List[str]] = None
+    operators: List[str] = Field(default_factory=lambda: DEFAULT_OPERATORS.copy())
+    max_tweets: int = Field(DEFAULT_MAX_TWEETS, ge=1, le=MAX_TWEETS)
+    lookup_period: Optional[str] = None
+    query_type: Literal["Latest", "Top"] = "Latest"
+    cred_info: XquikCredentials = Field(default_factory=lambda: XquikCredentials())
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+
+        if not self.cred_info.api_key.get_secret_value():
+            raise AttributeError(
+                "Xquik API key required. Set XQUIK_API_KEY or pass "
+                "cred_info=XquikCredentials(api_key='...')."
+            )
+
+
+class XquikSource(BaseSource):
+    NAME: ClassVar[str] = "Xquik"
+
+    _request_get: RequestGet = PrivateAttr()
+
+    def __init__(self, request_get: Optional[RequestGet] = None, **data: Any) -> None:
+        super().__init__(**data)
+        self._request_get = request_get or requests.get
+
+    def lookup(  # type: ignore[override]
+        self, config: XquikSourceConfig, **kwargs: Any
+    ) -> List[TextPayload]:
+        query = self._generate_query_string(
+            query=config.query,
+            keywords=config.keywords,
+            hashtags=config.hashtags,
+            usernames=config.usernames,
+            operators=config.operators,
+        )
+        if not query:
+            raise AttributeError(
+                "Set at least one query, keyword, hashtag, or username."
+            )
+
+        identifier: Optional[str] = kwargs.get("id")
+        state = self._get_state(identifier)
+        since_time = self._get_since_time(config.lookup_period, state)
+
+        tweets = self._fetch_tweets(
+            api_key=config.cred_info.api_key.get_secret_value(),
+            query=query,
+            max_tweets=config.max_tweets,
+            query_type=config.query_type,
+            since_time=since_time,
+        )
+        source_responses = [self._to_payload(tweet) for tweet in tweets]
+
+        newest_created = self._newest_created(tweets)
+        if (
+            identifier is not None
+            and self.store is not None
+            and newest_created is not None
+        ):
+            state["since_time"] = newest_created
+            self.store.update_source_state(workflow_id=identifier, state=state)
+
+        logger.info("Xquik fetched %d tweets", len(source_responses))
+        return source_responses
+
+    def _get_state(self, identifier: Optional[str]) -> Dict[str, Any]:
+        if identifier is None or self.store is None:
+            return {}
+        return self.store.get_source_state(identifier) or {}
+
+    @staticmethod
+    def _get_since_time(
+        lookup_period: Optional[str], state: Dict[str, Any]
+    ) -> Optional[str]:
+        candidates: List[datetime] = []
+        if lookup_period:
+            candidates.append(convert_utc_time(lookup_period))
+
+        stored_since_time = state.get("since_time")
+        if isinstance(stored_since_time, str):
+            try:
+                candidates.append(
+                    datetime.strptime(
+                        stored_since_time, DATETIME_STRING_PATTERN
+                    ).replace(tzinfo=timezone.utc)
+                )
+            except ValueError:
+                logger.warning("Ignoring invalid Xquik source state timestamp")
+
+        if not candidates:
+            return None
+        return max(candidates).strftime(DATETIME_STRING_PATTERN)
+
+    def _fetch_tweets(
+        self,
+        api_key: str,
+        query: str,
+        max_tweets: int,
+        query_type: str,
+        since_time: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "obsei",
+            "x-api-key": api_key,
+            "xquik-api-contract": XQUIK_API_CONTRACT,
+        }
+        tweets: List[Dict[str, Any]] = []
+        cursor: Optional[str] = None
+        seen_cursors: Set[str] = set()
+        page_requests = 0
+
+        while len(tweets) < max_tweets:
+            page_requests += 1
+            if page_requests > MAX_PAGE_REQUESTS:
+                raise ValueError("Xquik pagination exceeded the safety limit.")
+
+            params: Dict[str, Any] = {
+                "limit": max_tweets - len(tweets),
+                "q": query,
+                "queryType": query_type,
+            }
+            if cursor:
+                params["cursor"] = cursor
+            if since_time:
+                params["sinceTime"] = since_time
+
+            response = self._request_get(
+                XQUIK_SEARCH_ENDPOINT,
+                headers=headers,
+                params=params,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+                allow_redirects=False,
+            )
+            if 300 <= response.status_code < 400:
+                raise ValueError("Xquik redirected the API request.")
+            response.raise_for_status()
+            page = response.json()
+            if not isinstance(page, dict) or not isinstance(page.get("tweets"), list):
+                raise ValueError("Xquik returned an invalid tweet page.")
+
+            for tweet in page["tweets"]:
+                if not isinstance(tweet, dict):
+                    raise ValueError("Xquik returned an invalid tweet.")
+                tweets.append(tweet)
+                if len(tweets) == max_tweets:
+                    break
+
+            has_more = page.get("has_more")
+            if not isinstance(has_more, bool):
+                raise ValueError("Xquik returned invalid pagination metadata.")
+            if not has_more or len(tweets) == max_tweets:
+                break
+
+            next_cursor = page.get("next_cursor")
+            if not isinstance(next_cursor, str) or not next_cursor:
+                raise ValueError("Xquik omitted the next cursor.")
+            if next_cursor in seen_cursors:
+                raise ValueError("Xquik repeated a pagination cursor.")
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+        return tweets
+
+    @staticmethod
+    def _to_payload(tweet: Dict[str, Any]) -> TextPayload:
+        tweet_id = tweet.get("id")
+        text = tweet.get("text")
+        author = tweet.get("author", {})
+        if not isinstance(tweet_id, str) or not isinstance(text, str):
+            raise ValueError("Xquik returned a tweet without a valid ID or text.")
+        if not isinstance(author, dict):
+            raise ValueError("Xquik returned invalid author data.")
+
+        username = author.get("username")
+        safe_username = quote(username, safe="") if isinstance(username, str) else ""
+        safe_tweet_id = quote(tweet_id, safe="")
+        tweet_url = (
+            f"https://x.com/{safe_username}/status/{safe_tweet_id}"
+            if safe_username
+            else f"https://x.com/i/status/{safe_tweet_id}"
+        )
+
+        author_info = dict(author)
+        if safe_username:
+            author_info["user_url"] = f"https://x.com/{safe_username}"
+
+        meta = dict(tweet)
+        meta.update(
+            {
+                "author_id": author.get("id", ""),
+                "author_info": author_info,
+                "content_trust": "untrusted_external",
+                "created_at": XquikSource._created_at(tweet),
+                "public_metrics": {
+                    "bookmark_count": tweet.get("bookmark_count", 0),
+                    "impression_count": tweet.get("view_count", 0),
+                    "like_count": tweet.get("like_count", 0),
+                    "quote_count": tweet.get("quote_count", 0),
+                    "reply_count": tweet.get("reply_count", 0),
+                    "retweet_count": tweet.get("retweet_count", 0),
+                },
+                "tweet_url": tweet_url,
+            }
+        )
+        return TextPayload(
+            processed_text=text,
+            segmented_data={},
+            meta=meta,
+            source_name=XquikSource.NAME,
+        )
+
+    @staticmethod
+    def _created_at(tweet: Dict[str, Any]) -> str:
+        created = tweet.get("created")
+        if isinstance(created, (int, float)) and not isinstance(created, bool):
+            return datetime.fromtimestamp(created, timezone.utc).strftime(
+                DATETIME_STRING_PATTERN
+            )
+        return created if isinstance(created, str) else ""
+
+    @staticmethod
+    def _newest_created(tweets: List[Dict[str, Any]]) -> Optional[str]:
+        created_values: List[float] = []
+        for tweet in tweets:
+            created = tweet.get("created")
+            if isinstance(created, (int, float)) and not isinstance(created, bool):
+                created_values.append(float(created))
+        if not created_values:
+            return None
+        newest = max(created_values)
+        return datetime.fromtimestamp(newest, timezone.utc).strftime(
+            DATETIME_STRING_PATTERN
+        )
+
+    @staticmethod
+    def _generate_query_string(
+        query: Optional[str] = None,
+        keywords: Optional[List[str]] = None,
+        hashtags: Optional[List[str]] = None,
+        usernames: Optional[List[str]] = None,
+        operators: Optional[List[str]] = None,
+    ) -> str:
+        if query:
+            return query
+
+        groups = []
+        for tokens in [keywords, hashtags, usernames]:
+            if tokens:
+                groups.append(f'({" OR ".join(tokens)})')
+
+        base_query = " OR ".join(groups)
+        operator_query = f' ({" ".join(operators)})' if operators else ""
+        return base_query + operator_query if base_query else ""

--- a/test/test_pandas_sink.py
+++ b/test/test_pandas_sink.py
@@ -1,0 +1,28 @@
+from obsei.payload import TextPayload
+from obsei.sink.pandas_sink import PandasSink, PandasSinkConfig
+
+
+def test_pandas_sink_appends_rows_with_supported_pandas_api():
+    config = PandasSinkConfig()
+    responses = [
+        TextPayload(processed_text="first", source_name="Test"),
+        TextPayload(processed_text="second", source_name="Test"),
+    ]
+
+    result = PandasSink().send_data(responses, config)
+
+    assert result[["processed_text", "source_name"]].to_dict("records") == [
+        {"processed_text": "first", "source_name": "Test"},
+        {"processed_text": "second", "source_name": "Test"},
+    ]
+
+
+def test_pandas_sink_filters_included_columns():
+    config = PandasSinkConfig(include_columns_list=["processed_text"])
+
+    result = PandasSink().send_data(
+        [TextPayload(processed_text="first", source_name="Test")],
+        config,
+    )
+
+    assert result.to_dict("records") == [{"processed_text": "first"}]

--- a/test/test_xquik_source.py
+++ b/test/test_xquik_source.py
@@ -1,0 +1,329 @@
+from typing import Any, Dict, List, Optional
+
+import pytest
+from pydantic import Field
+
+from obsei.source.xquik_source import (
+    MAX_PAGE_REQUESTS,
+    REQUEST_TIMEOUT_SECONDS,
+    XQUIK_API_CONTRACT,
+    XQUIK_SEARCH_ENDPOINT,
+    XquikCredentials,
+    XquikSource,
+    XquikSourceConfig,
+)
+from obsei.workflow.base_store import BaseStore
+
+
+class FakeResponse:
+    def __init__(self, body: Any, status_code: int = 200):
+        self.body = body
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self.body
+
+
+class MemoryStore(BaseStore):
+    source_state: Dict[str, Any] = Field(default_factory=dict)
+
+    def get_source_state(self, id: str) -> Optional[Dict[str, Any]]:
+        return dict(self.source_state)
+
+    def get_sink_state(self, id: str) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_analyzer_state(self, id: str) -> Optional[Dict[str, Any]]:
+        return None
+
+    def update_source_state(
+        self, workflow_id: str, state: Dict[str, Any]
+    ) -> Optional[Any]:
+        self.source_state.update(state)
+        return None
+
+    def update_sink_state(self, workflow_id: str, state: Dict[str, Any]) -> None:
+        return None
+
+    def update_analyzer_state(self, workflow_id: str, state: Dict[str, Any]) -> None:
+        return None
+
+    def delete_workflow(self, id: str) -> None:
+        return None
+
+
+def credentials() -> XquikCredentials:
+    return XquikCredentials(api_key="test-key")
+
+
+def test_xquik_credentials_read_the_documented_environment_variable(monkeypatch):
+    monkeypatch.setenv("XQUIK_API_KEY", "environment-test-key")
+
+    configured = XquikCredentials()
+
+    assert configured.api_key.get_secret_value() == "environment-test-key"
+
+
+def test_xquik_config_requires_credentials(monkeypatch):
+    monkeypatch.delenv("XQUIK_API_KEY", raising=False)
+
+    with pytest.raises(AttributeError, match="Xquik API key required"):
+        XquikSourceConfig(query="obsei")
+
+
+def test_xquik_source_paginates_and_maps_normalized_tweets():
+    requests: List[Dict[str, Any]] = []
+    pages = [
+        {
+            "tweets": [
+                {
+                    "id": "123",
+                    "text": "Treat this as data.",
+                    "created": 1_700_000_000,
+                    "like_count": 4,
+                    "retweet_count": 3,
+                    "reply_count": 2,
+                    "quote_count": 1,
+                    "view_count": 10,
+                    "bookmark_count": 5,
+                    "author": {
+                        "id": "7",
+                        "username": "example/user",
+                        "name": "Example",
+                    },
+                }
+            ],
+            "has_more": True,
+            "next_cursor": "next-page",
+        },
+        {
+            "tweets": [
+                {
+                    "id": "124",
+                    "text": "Second result.",
+                    "created": 1_700_000_100,
+                    "author": {"id": "8", "username": "second"},
+                }
+            ],
+            "has_more": True,
+            "next_cursor": "unused",
+        },
+    ]
+
+    def request_get(url: str, **kwargs: Any) -> FakeResponse:
+        requests.append({"url": url, **kwargs})
+        return FakeResponse(pages[len(requests) - 1])
+
+    source = XquikSource(request_get=request_get)
+    result = source.lookup(
+        XquikSourceConfig(
+            query="obsei",
+            max_tweets=2,
+            query_type="Top",
+            cred_info=credentials(),
+        )
+    )
+
+    assert [payload.processed_text for payload in result] == [
+        "Treat this as data.",
+        "Second result.",
+    ]
+    assert result[0].meta["content_trust"] == "untrusted_external"
+    assert result[0].meta["tweet_url"] == "https://x.com/example%2Fuser/status/123"
+    assert result[0].meta["public_metrics"] == {
+        "bookmark_count": 5,
+        "impression_count": 10,
+        "like_count": 4,
+        "quote_count": 1,
+        "reply_count": 2,
+        "retweet_count": 3,
+    }
+    assert requests == [
+        {
+            "url": XQUIK_SEARCH_ENDPOINT,
+            "headers": {
+                "Accept": "application/json",
+                "User-Agent": "obsei",
+                "x-api-key": "test-key",
+                "xquik-api-contract": XQUIK_API_CONTRACT,
+            },
+            "params": {"limit": 2, "q": "obsei", "queryType": "Top"},
+            "timeout": REQUEST_TIMEOUT_SECONDS,
+            "allow_redirects": False,
+        },
+        {
+            "url": XQUIK_SEARCH_ENDPOINT,
+            "headers": {
+                "Accept": "application/json",
+                "User-Agent": "obsei",
+                "x-api-key": "test-key",
+                "xquik-api-contract": XQUIK_API_CONTRACT,
+            },
+            "params": {
+                "cursor": "next-page",
+                "limit": 1,
+                "q": "obsei",
+                "queryType": "Top",
+            },
+            "timeout": REQUEST_TIMEOUT_SECONDS,
+            "allow_redirects": False,
+        },
+    ]
+
+
+def test_xquik_source_rejects_repeated_pagination_cursor():
+    def request_get(url: str, **kwargs: Any) -> FakeResponse:
+        return FakeResponse({"tweets": [], "has_more": True, "next_cursor": "repeated"})
+
+    source = XquikSource(request_get=request_get)
+
+    with pytest.raises(ValueError, match="repeated a pagination cursor"):
+        source.lookup(XquikSourceConfig(query="obsei", cred_info=credentials()))
+
+
+def test_xquik_source_bounds_empty_paginated_results():
+    request_count = 0
+
+    def request_get(url: str, **kwargs: Any) -> FakeResponse:
+        nonlocal request_count
+        request_count += 1
+        return FakeResponse(
+            {
+                "tweets": [],
+                "has_more": True,
+                "next_cursor": f"cursor-{request_count}",
+            }
+        )
+
+    source = XquikSource(request_get=request_get)
+
+    with pytest.raises(ValueError, match="exceeded the safety limit"):
+        source.lookup(XquikSourceConfig(query="obsei", cred_info=credentials()))
+    assert request_count == MAX_PAGE_REQUESTS
+
+
+def test_xquik_source_refuses_redirects_before_sending_another_request():
+    source = XquikSource(
+        request_get=lambda *args, **kwargs: FakeResponse({}, status_code=302)
+    )
+
+    with pytest.raises(ValueError, match="redirected the API request"):
+        source.lookup(XquikSourceConfig(query="obsei", cred_info=credentials()))
+
+
+@pytest.mark.parametrize(
+    ("page", "message"),
+    [
+        ({}, "invalid tweet page"),
+        (
+            {
+                "tweets": [None],
+                "has_more": False,
+                "next_cursor": "",
+            },
+            "invalid tweet",
+        ),
+        (
+            {
+                "tweets": [],
+                "has_more": "yes",
+                "next_cursor": "",
+            },
+            "invalid pagination metadata",
+        ),
+        (
+            {
+                "tweets": [],
+                "has_more": True,
+                "next_cursor": "",
+            },
+            "omitted the next cursor",
+        ),
+    ],
+)
+def test_xquik_source_rejects_invalid_pages(page, message):
+    source = XquikSource(request_get=lambda *args, **kwargs: FakeResponse(page))
+
+    with pytest.raises(ValueError, match=message):
+        source.lookup(XquikSourceConfig(query="obsei", cred_info=credentials()))
+
+
+@pytest.mark.parametrize(
+    ("tweet", "message"),
+    [
+        ({"id": 1, "text": "text"}, "without a valid ID or text"),
+        ({"id": "1", "text": "text", "author": []}, "invalid author data"),
+    ],
+)
+def test_xquik_source_rejects_invalid_tweet_fields(tweet, message):
+    with pytest.raises(ValueError, match=message):
+        XquikSource._to_payload(tweet)
+
+
+def test_xquik_source_requires_a_query():
+    source = XquikSource(request_get=lambda *args, **kwargs: FakeResponse({}))
+
+    with pytest.raises(AttributeError, match="Set at least one"):
+        source.lookup(XquikSourceConfig(cred_info=credentials()))
+
+
+def test_xquik_source_uses_and_advances_workflow_state():
+    request_params: List[Dict[str, Any]] = []
+    store = MemoryStore(source_state={"since_time": "2023-11-14T22:13:00Z"})
+
+    def request_get(url: str, **kwargs: Any) -> FakeResponse:
+        request_params.append(kwargs["params"])
+        return FakeResponse(
+            {
+                "tweets": [
+                    {
+                        "id": "124",
+                        "text": "New result.",
+                        "created": 1_700_000_100,
+                    }
+                ],
+                "has_more": False,
+                "next_cursor": "",
+            }
+        )
+
+    source = XquikSource(request_get=request_get, store=store)
+    source.lookup(
+        XquikSourceConfig(query="obsei", cred_info=credentials()),
+        id="workflow-1",
+    )
+
+    assert request_params[0]["sinceTime"] == "2023-11-14T22:13:00Z"
+    assert store.source_state["since_time"] == "2023-11-14T22:15:00Z"
+
+
+def test_xquik_source_handles_time_boundaries_and_optional_tweet_fields():
+    assert (
+        XquikSource._get_since_time(
+            "2023-11-14T22:13:00Z",
+            {"since_time": "2023-11-14T22:15:00Z"},
+        )
+        == "2023-11-14T22:15:00Z"
+    )
+    assert XquikSource._get_since_time(None, {"since_time": "not-a-time"}) is None
+
+    payload = XquikSource._to_payload(
+        {"id": "123", "text": "Text", "created": "2023-11-14T22:15:00Z"}
+    )
+    assert payload.meta["created_at"] == "2023-11-14T22:15:00Z"
+    assert payload.meta["tweet_url"] == "https://x.com/i/status/123"
+    assert XquikSource._newest_created([{"created": False}, {}]) is None
+
+
+def test_xquik_source_builds_compatible_grouped_query():
+    query = XquikSource._generate_query_string(
+        keywords=["obsei", "automation"],
+        hashtags=["#nlp"],
+        usernames=["from:ObseiAI"],
+        operators=["-is:reply"],
+    )
+
+    assert query == ("(obsei OR automation) OR (#nlp) OR (from:ObseiAI) (-is:reply)")


### PR DESCRIPTION
## Summary

- Add a production-ready Xquik Observer for public X search.
- Preserve Obsei's existing `TextPayload` and Twitter metadata shape.
- Fix the Pandas 2 sink failure reported in #332.
- Add focused regression coverage for both changes.

## Xquik Observer

The Observer uses the fixed Xquik HTTPS search endpoint. It sends the API key
only through the request header. It also disables redirects, uses structured
query parameters, enforces a 15-second timeout, and bounds pagination.

The source opts into Xquik's normalized API contract. It follows cursors,
rejects malformed pages, and advances Obsei workflow state by creation time.
Tweet text remains raw analysis data. Metadata marks it as untrusted external
content.

Users can configure `XQUIK_API_KEY` and run the included example. The README
documents the source and Xquik's independence from X Corp.

## Independent Fix

Fixes #332.

Pandas 2 removed `DataFrame.append`. `PandasSink` now uses `pandas.concat` and
retains the existing row conversion behavior. Regression tests cover the
default empty DataFrame and column filtering.

## Validation

- Focused Python 3.8 tests: 18 passed.
- Changed-module branch coverage: 99%.
- Python 3.8, 3.9, 3.10, and 3.11 compilation passed.
- Black check passed on every changed Python file.
- Mypy passed on both changed source modules.
- Bandit reported no findings.
- Source distribution and wheel builds passed.
- Twine validated both artifacts.
- The current public OpenAPI contract and unauthenticated boundary were verified.
- `git diff --check` passed.

The repository's pinned pre-commit `types-all` environment no longer resolves
because one of its packages is unavailable. The equivalent Black, mypy, test,
and file checks passed independently.
